### PR TITLE
Match unicode lambda

### DIFF
--- a/grammars/racket.cson
+++ b/grammars/racket.cson
@@ -395,7 +395,7 @@ repository:
         begin: '''
           (?x)
           						(?<=\\() # preceded by (
-          						(lambda)\\s+
+          						(lambda|λ)\\s+
           						(\\() # opening paren
           						((?:
           						  ([[:alnum:]][[:alnum:]!$%&*+-./:<=>?@^_~]*|[._])


### PR DESCRIPTION
This changes the `(lambda)` regex to `(lambda|λ)`, so that the λ character is also matched. This is appropriate, since importing lambda in racket also imports the λ alias. Fixes #7
