### PR TITLE
Recognize `#true` and `#false` as booleans

### DIFF
--- a/grammars/racket.cson
+++ b/grammars/racket.cson
@@ -79,7 +79,7 @@ repository:
   constants:
     patterns: [
       {
-        match: "#[t|f]"
+        match: "#(t(rue)?|f(alse)?)"
         name: "constant.language.boolean.racket"
       }
       {


### PR DESCRIPTION
Before, only `#t` and `#f` were highlighted.